### PR TITLE
feat(shared): responsive fix ; contact html

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -163,8 +163,8 @@
         </div>
       </aside>
 
-      <main class="flex-1 p-4 md:p-6 pt-20 md:pt-3.5 md:ml-72 md:max-h-screen">
-        <div class="max-w-3xl mx-auto">
+      <main class="flex-1 p-4 md:p-6 pt-20 md:pt-3.5 md:ml-72">
+        <div class="max-w-3xl mx-auto pb-24">
           <div class="mb-6">
             <h2 class="text-2xl font-semibold mb-2 text-gray-900 dark:text-white">Contact</h2>
             <p class="text-gray-600 dark:text-gray-400 text-base">Let's get in touch.</p>
@@ -359,6 +359,7 @@
         </div>
       </main>
     </div>
+
     <script src="script.js"></script>
 
     <!-- Footer -->

--- a/src/output.css
+++ b/src/output.css
@@ -390,6 +390,9 @@
   .h-2 {
     height: calc(var(--spacing) * 2);
   }
+  .h-4 {
+    height: calc(var(--spacing) * 4);
+  }
   .h-8 {
     height: calc(var(--spacing) * 8);
   }
@@ -742,6 +745,9 @@
   .pt-20 {
     padding-top: calc(var(--spacing) * 20);
   }
+  .pb-24 {
+    padding-bottom: calc(var(--spacing) * 24);
+  }
   .pl-4 {
     padding-left: calc(var(--spacing) * 4);
   }
@@ -969,14 +975,6 @@
       }
     }
   }
-  .hover\:-translate-y-0\.5 {
-    &:hover {
-      @media (hover: hover) {
-        --tw-translate-y: calc(var(--spacing) * -0.5);
-        translate: var(--tw-translate-x) var(--tw-translate-y);
-      }
-    }
-  }
   .hover\:-translate-y-1 {
     &:hover {
       @media (hover: hover) {
@@ -1119,6 +1117,11 @@
       height: calc(var(--spacing) * 14);
     }
   }
+  .md\:h-screen {
+    @media (width >= 48rem) {
+      height: 100vh;
+    }
+  }
   .md\:max-h-screen {
     @media (width >= 48rem) {
       max-height: 100vh;
@@ -1158,6 +1161,11 @@
   .md\:items-center {
     @media (width >= 48rem) {
       align-items: center;
+    }
+  }
+  .md\:overflow-hidden {
+    @media (width >= 48rem) {
+      overflow: hidden;
     }
   }
   .md\:p-6 {


### PR DESCRIPTION
This pull request introduces updates to the `contact.html` layout and enhancements to the `src/output.css` stylesheet. The changes improve the visual structure of the contact page, add new utility classes for spacing and responsiveness, and remove an unused hover utility.

### Layout updates in `contact.html`:

* Added a bottom padding (`pb-24`) to the main content container for improved spacing.
* Minor adjustment: Added a blank line before the `<script>` tag for better readability.

### New utility classes in `src/output.css`:

* Added `.h-4` for height and `.pb-24` for padding-bottom to extend spacing options. [[1]](diffhunk://#diff-b767acb30cbca0248a54f8a2e14f64f743274f96dd1c32057d51844fd93b262cR393-R395) [[2]](diffhunk://#diff-b767acb30cbca0248a54f8a2e14f64f743274f96dd1c32057d51844fd93b262cR748-R750)
* Introduced `.md\:h-screen` for setting height to 100vh on medium screens and above.
* Added `.md\:overflow-hidden` to control overflow on medium screens and above.

### Code cleanup in `src/output.css`:

* Removed the `.hover\:-translate-y-0\.5` class as it was unused.